### PR TITLE
Loadouts - Add Chernorussian Green Sea Bataillon in Summer

### DIFF
--- a/loadouts/fictional/loadouts/README.md
+++ b/loadouts/fictional/loadouts/README.md
@@ -1,5 +1,37 @@
 # Loadouts
 
+## 2024, Green Sea Bataillon in EMR Summer
+**File:** `crn_2024_green-sea-bataillon_summer_v5.sqf`
+
+**Modpack Version:** `v6`
+
+**Template Version:** `1.3`
+
+**Roles:** 
+- `RFL` Rifleman
+- `SL` Squad Leader
+- `FTL` Fireteam Leader
+- `MED` Medic
+- `AR` Automatic Rifleman
+- `GRD` Grenadier
+- `LAT` Anti-Tank, Light
+
+**Description:**
+<!-- Description -->
+Cluster Community modpack adjusted interpretaion of the "Green Sea Bataillon" seen in other mods dealing with the Chernorussia lore.
+The Green Sea Bataillon mostly has eastern style gear but a western modernisation is seen throuout their equipment.
+Inside the loadout is also a ID armband in the colors green and yellow. The enemy armband colors should be either white or red. 
+
+**Country:** Chernorussia
+
+**ID Armband Colors:** Green, Yellow
+
+**Associated Files:**
+<!-- List of templates associated with this e.g. garage and logistics templates -->
+- crn_2024_Green-Sea-Bataillon_logistics_summer_v6
+
+---
+
 ## 2020 Chernarus Defence Forces (CDF) in ATACS
 **File:** `cdf_2020_cherno-sso_atac.sqf`
 
@@ -313,8 +345,8 @@ Escape from Tarkov Inspired loadout
 
 ---
 
-## Fictional Modern African Special Forces in Tan
-**File:** `fic_na_african-modern-SOF_Tan.sqf`
+## 2020 Chernarus Defence Forces (CDF) in ATACS
+**File:** `cdf_2020_cherno-sso_atac.sqf`
 
 **Modpack Version:** `??`
 
@@ -323,19 +355,23 @@ Escape from Tarkov Inspired loadout
 **Roles:** 
 - `RFL` Rifleman
 - `SL` Squad Leader
-- `FTL` Fireteam Leader
 - `MED` Medic
-- `GRD` Grenadier
-- `LAT` Anti-Tank, Light
 - `MMG` Machinegunner, Medium
+- `GRD` Grenadier
+- `ENG` Engineer
 
 **Description:**
 <!-- Description -->
-Fictional Modern African Special Forces in Tan
+2020 Chernarus Defence Forces (CDF) in ATACS
 
 <!-- File Meta Data e.g. **Country:** Russia -->
+**Country:** Chernarus
+
+**Year:** 2020
+
 
 **Associated Files:**
 <!-- List of templates associated with this e.g. garage and logistics templates -->
+
 
 ---

--- a/loadouts/fictional/loadouts/crn_2020_specialized-motorized-infantry_summer.sqf
+++ b/loadouts/fictional/loadouts/crn_2020_specialized-motorized-infantry_summer.sqf
@@ -1,3 +1,13 @@
+/*
+ * Made for Arma 3 Virtual MILSIM
+ *
+ * Author: Hark
+ * CC Modpack Version: ??
+ * 2020 "Modernized" Chernarus Defence Forces (CDF) SSO in EMR
+ *
+ * https://github.com/clustermod/CMF3/blob/dev/framework/rsc/loadouts/!arsenal_template.sqf
+ */
+
 params ["_role", "_unit"];
 
 /* Custom additional condition */

--- a/loadouts/fictional/loadouts/crn_2024_green-sea-bataillon_summer_v6.sqf
+++ b/loadouts/fictional/loadouts/crn_2024_green-sea-bataillon_summer_v6.sqf
@@ -1,0 +1,132 @@
+/*
+ * Made for Arma 3 Virtual MILSIM
+ *
+ * Author: Hark
+ * CC Modpack Version: v5
+ * Cluster Community modpack adjusted interpretaion of the "Green Sea Bataillon" seen in other mods dealing with the Chernorussia lore.
+ * The Green Sea Bataillon mostly has eastern style gear but a western modernisation is seen throuout their equipment.
+ * Inside the loadout is also a ID armband in the colors green and yellow. The enemy armband colors should be either white or red. 
+ * 
+ * https://github.com/clustermod/CMF3/blob/dev/framework/rsc/loadouts/!arsenal_template.sqf
+ */
+params ["_role", "_unit"];
+
+/* Custom additional condition */
+private _condition = true;
+private ["_availableUniforms", "_availableWeapons", "_availableMagazines", "_availableVests", "_availableItems", "_availableBackpacks", "_availableHeadgear", "_availableFacewear", "_availableAttachments", "_availableGrenades"];
+
+/* Default gear */
+private _defItems = ["ACE_Canteen", "ACE_EarPlugs", "kat_guedel", "ACE_adenosine", "ACE_fieldDressing", "ACE_elasticBandage", "ACE_packingBandage", "ACE_quikclot", "ACE_epinephrine", "ACE_Flashlight_MX991", "ACE_MapTools", "ACE_morphine", "ACE_splint", "ACE_tourniquet", "ItemMap", "ItemCompass", "ItemWatch", "ACE_CableTie"];
+private _defWeapons = ["rhs_weap_rpg75", "rhs_weap_tt33"];
+private _defAttachments = [];
+private _defMagazines = ["rhs_30Rnd_545x39_7N10_plum_AK", "rhsgref_30rnd_556x45_vhs2", "rhsusf_200Rnd_556x45_box", "rhs_rpg7_OG7V_mag", "rhs_rpg7_TBG7V_mag", "rhs_rpg7_PG7VL_mag", "rhs_mag_762x25_8", "rhs_VG40TB", "rhs_VOG25P", "rhs_VG40OP_green", "rhs_VG40OP_red", "rhs_VG40OP_white"];
+private _defGrenades = ["BWA3_DM51A1", "BWA3_DM32_Yellow", "BWA3_DM32_Red", "BWA3_DM32_Purple", "BWA3_DM32_Orange", "BWA3_DM32_Green", "BWA3_DM32_Blue", "BWA3_DM25", "Chemlight_blue", "Chemlight_green", "Chemlight_red", "Chemlight_yellow", "ACE_Chemlight_Orange", "ACE_M84", "rhs_mag_an_m14_th3", "ACE_Chemlight_IR"];
+private _defUniforms = ["CUP_U_O_RUS_Ratnik_Summer"];
+private _defVests = [];
+private _defBackpacks = [];
+private _defHeadgear = ["rhs_6b27m_green", "rhsusf_opscore_fg_pelt", "rhsusf_opscore_mar_fg_pelt", "rhsusf_opscore_fg", "rhsusf_opscore_rg_cover"];
+private _defFacewear = [/*ID-Armband in Green --> */"Armband_Green_large", "Armband_Yellow_large"/* <-- ID-Armband in Green */];
+
+/* Rifleman */
+if (_condition && _role in ["RFL"]) then {
+    _availableUniforms = [];
+    _availableWeapons = ["rhs_weap_ak74m_npz", "rhs_weap_vhsd2_ct15x"];
+    _availableAttachments = ["rhsusf_acc_T1_high", "Tier1_EXPS3_0_Black"];
+    _availableMagazines = [];
+    _availableVests = ["CUP_Vest_RUS_6B45_Sh117_Nut", "CUP_Vest_RUS_6B45_Sh117"];
+    _availableItems = [];
+    _availableGrenades = [];
+    _availableBackpacks = ["rhs_tortila_grey", "rhs_tortila_emr"];
+    _availableHeadgear = [];
+    _availableFacewear = [];
+};
+
+/* Squad Leader and Fireteam Leader */
+if (_condition && _role in ["SL", "FTL"]) then {
+    _availableUniforms = [];
+    _availableWeapons = ["rhs_weap_ak74m_gp25_npz", "rhsusf_bino_m24"];
+    _availableAttachments = ["rhsusf_acc_ACOG", "rhs_acc_dtk1983"];
+    _availableMagazines = [];
+    _availableVests = ["CUP_Vest_RUS_6B45_Sh117_VOG"];
+    _availableItems = [];
+    _availableGrenades = [];
+    _availableBackpacks = ["rhs_tortila_grey", "rhs_tortila_emr"];
+    _availableHeadgear = [];
+    _availableFacewear = [];
+};
+
+/* Medic */
+if (_condition && _role in ["MED"]) then {
+    _unit setVariable ["ace_medical_medicclass", 2, true];
+    _availableUniforms = [];
+    _availableWeapons = ["rhs_weap_ak74m_npz", "rhs_weap_vhsd2_ct15x"];
+    _availableAttachments = ["rhsusf_acc_T1_high", "Tier1_EXPS3_0_Black"];
+    _availableMagazines = [];
+    _availableVests = ["CUP_Vest_RUS_6B45_Sh117_Nut", "CUP_Vest_RUS_6B45_Sh117"];
+    _availableItems = ["ACE_personalAidKit", "ACE_plasmaIV", "ACE_plasmaIV_250", "ACE_plasmaIV_500", "ACE_surgicalKit", "kat_chestSeal", "kat_larynx", "kat_stethoscope", "kat_amiodarone", "kat_lidocaine", "kat_IO_FAST", "kat_IV_16", "KAT_Empty_bloodIV_500", "KAT_Empty_bloodIV_250", "kat_AED", "kat_aatKit"];
+    _availableGrenades = [];
+    _availableBackpacks = ["rhs_tortila_grey", "rhs_tortila_emr"];
+    _availableHeadgear = [];
+    _availableFacewear = [];
+};
+
+/* Autorifleman */
+if (_condition && _role in ["AR"]) then {
+    _availableUniforms = [];
+    _availableWeapons = ["rhs_weap_m249_pip_S_para"];
+    _availableAttachments = ["Tier1_Eotech553_Black", "rhsusf_acc_grip4_bipod"];
+    _availableMagazines = [];
+    _availableVests = ["CUP_Vest_RUS_6B45_Sh117_PKP_Nut"];
+    _availableItems = [];
+    _availableGrenades = [];
+    _availableBackpacks = ["rhs_tortila_grey", "rhs_tortila_emr"];
+    _availableHeadgear = [];
+    _availableFacewear = [];
+};
+
+/* Anti-Tank, Light */
+if (_condition && _role in ["LAT"]) then {
+    _availableUniforms = [];
+    _availableWeapons = ["rhs_weap_ak74m_npz", "rhs_weap_vhsd2_ct15x", "CUP_launch_RPG7V"];
+    _availableAttachments = ["rhsusf_acc_T1_high", "Tier1_EXPS3_0_Black", "CUP_optic_NSPU_RPG"];
+    _availableMagazines = [];
+    _availableVests = [];
+    _availableItems = [];
+    _availableGrenades = [];
+    _availableBackpacks = ["rhs_rpg_empty", "rhs_rpg_6b3"];
+    _availableHeadgear = [];
+    _availableFacewear = [];
+};
+
+/* Grenadier */
+if (_condition && _role in ["GRD"]) then {
+    _availableUniforms = [];
+    _availableWeapons = ["rhs_weap_ak74m_gp25_npz"];
+    _availableAttachments = ["rhsusf_acc_ACOG", "rhs_acc_dtk1983"];
+    _availableMagazines = [];
+    _availableVests = ["CUP_Vest_RUS_6B45_Sh117_VOG"];
+    _availableItems = [];
+    _availableGrenades = [];
+    _availableBackpacks = ["rhs_tortila_grey", "rhs_tortila_emr"];
+    _availableHeadgear = [];
+    _availableFacewear = [];
+};
+
+/* Loadout array that's passed back to kosherArsenal */
+[
+    /* Loadoutfile version */
+    "1.3",
+
+    /* Allowed Equipment array */
+    [
+        (_availableBackpacks + _defBackpacks),
+        (_availableVests + _defVests),
+        (_availableUniforms + _defUniforms),
+        (_availableFacewear + _defFacewear),
+        (_defHeadgear + _availableHeadgear),
+        (_defAttachments + _availableAttachments),
+        (_availableMagazines + _defGrenades + _defMagazines + _availableGrenades),
+        (_availableWeapons + _defWeapons),
+        (_availableItems + _defItems)
+    ]
+];

--- a/loadouts/fictional/logistics/README.md
+++ b/loadouts/fictional/logistics/README.md
@@ -1,1 +1,27 @@
 # Logistic Templates
+
+## 2024 Chernorussia Green Sea Bataillon Logistics
+**Modpack Version:** `cc_core_v5`
+
+**Template Version:** `1.0`
+<!-- Crates -->
+**Crates:** 
+- x2 `Fireteam`
+- x2 `Medical`
+- x1 `Explosives`
+
+<!-- Description -->
+Logistical crates for 2024 Chernorussia Green Sea Bataillon
+<!-- Information about file e.g. country: Russia-->
+
+**Country:** Chernorussia
+
+**Associated Files:**
+- crn_2024_green-sea-bataillon_summer_v6
+<!-- List of templates associated with this e.g. garage and logistics templates -->
+<br/><br/>
+<a href="https://raw.githubusercontent.com/clustermod/HCMF3-Loadouts/master/loadouts/fictional/logistics/crn_2024_Green-Sea-Bataillon_logistics_summer_v6.sqf">
+  <img alt="Static Badge" src="https://img.shields.io/badge/File-Download_(CTRL_%2B_S)-orange?style=flat-square">
+</a>
+
+---

--- a/loadouts/fictional/logistics/crn_2024_Green-Sea-Bataillon_logistics_summer_v6.sqf
+++ b/loadouts/fictional/logistics/crn_2024_Green-Sea-Bataillon_logistics_summer_v6.sqf
@@ -1,0 +1,47 @@
+/*
+ * Made for Arma 3 Virtual MILSIM
+ *
+ * Author: Hark
+ * CC Modpack Version: v5
+ * Cluster Community modpack adjusted interpretaion of the "Green Sea Bataillon" seen in other mods dealing with the Chernorussia lore.
+ * The Green Sea Bataillon mostly has eastern style gear but a western modernisation is seen throuout their equipment.
+ * Inside the loadout is also a ID armband in the colors green and yellow. The enemy armband colors should be either white or red. 
+ * 
+ * https://github.com/clustermod/CMF3/blob/dev/framework/rsc/loadouts/!arsenal_template.sqf
+ */
+
+[
+    /* Fireteam Crate */
+    ["Fireteam", {
+        _available = 2;
+        _class = "CUP_BOX_US_ARMY_Ammo_F";
+        _weapons = [];
+        /* Change Values in between the qoutes to object classnames. */
+        _magazines = [["rhs_30Rnd_545x39_7N10_plum_AK", 25], ["rhsgref_30rnd_556x45_vhs2", 25], ["rhsusf_200Rnd_556x45_box",10], ["rhs_weap_rpg75",2 ], ["rhs_VOG25P",15], ["rhs_VG40OP_green",10]];
+        /* Change Values in between the qoutes to object classnames. */
+        _grenades = [["BWA3_DM51A1", 15]];
+        _items = [["ACE_fieldDressing", 12],  ["ACE_morphine", 12], ["ACE_canteen", 6]];
+        _cargo = [];
+    }],
+    
+    ["Medical", {
+        _available = 2;
+        _class = "ACE_medicalSupplyCrate_advanced";
+        _weapons = [];
+        _magazines = [];
+        _grenades = [];
+        _items = [["kat_IV_16", 10], ["kat_aatKit", 5], ["ACE_adenosine", 5], ["kat_amiodarone", 5], ["ACE_fieldDressing", 20], ["ACE_elasticBandage", 25], ["ACE_packingBandage", 30], ["ACE_quikclot", 15], ["kat_chestSeal", 10], ["ACE_epinephrine", 10], ["kat_IO_FAST", 5], ["kat_guedel", 5], ["kat_larynx", 10], ["kat_lidocaine", 5], ["ACE_morphine", 10], ["ACE_plasmaIV", 5], ["ACE_plasmaIV_500", 10], ["ACE_splint", 5], ["ACE_bodyBag", 10]];
+        _cargo = [];
+    }],
+    
+    ["Explosives", {
+        _available = 1;
+        _class = "CUP_BOX_US_ARMY_AmmoOrd_F";
+        _weapons = [];
+        /* Change Values in between the qoutes to object classnames. */
+        _magazines = [["rhsusf_m112x4_mag", 10]];
+        _grenades = [];
+        _items = [];
+        _cargo = [];
+    }]
+]


### PR DESCRIPTION
**When merged this pull request will:**
- add `crn_2024_green-sea-bataillon_summer_v5.sqf`
- add `crn_2024_Green-Sea-Bataillon_logistics_summer_v6.sqf`
- fix missing loadout header in one file

### IMPORTANT
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
- [x] Loadouts use standard [filename format](https://github.com/clustermod/HCMF3-Loadouts/wiki#standardization).
- [x] Loadouts are listed and documented in the respective readme file.